### PR TITLE
fix: remove deprecated nvim-treesitter.ts_utils import

### DIFF
--- a/lua/phprefactoring/parser.lua
+++ b/lua/phprefactoring/parser.lua
@@ -2,7 +2,6 @@
 -- Integrates with Treesitter for accurate PHP code analysis
 
 local config = require('phprefactoring.config')
-local ts_utils = require('nvim-treesitter.ts_utils')
 
 local M = {}
 


### PR DESCRIPTION
## Summary
- Removes the unused import of `nvim-treesitter.ts_utils` which has been deprecated and removed in recent nvim-treesitter versions
- Fixes module not found errors when loading the plugin

## Details
The `nvim-treesitter.ts_utils` module has been removed in recent versions of nvim-treesitter. This import was not being used anywhere in the codebase - all treesitter functionality already uses the native Neovim treesitter API (`vim.treesitter.*`).

## Test plan
- [x] Module loads without errors
- [x] All existing refactoring operations continue to work
- [x] No regression in functionality
