### PR TITLE
fix: remove deprecated nvim-treesitter.ts_utils import

### DIFF
--- a/lua/phprefactoring/parser.lua
+++ b/lua/phprefactoring/parser.lua
@@ -2,7 +2,6 @@
 -- Integrates with Treesitter for accurate PHP code analysis
 
 local config = require('phprefactoring.config')
-local ts_utils = require('nvim-treesitter.ts_utils')
 
 local M = {}
 


### PR DESCRIPTION
The nvim-treesitter.ts_utils module has been removed in recent versions of nvim-treesitter. This import was unused and causing module not found errors. The code already uses the native Neovim treesitter API.